### PR TITLE
DALTON: default boilerplate using Open Babel

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,6 +41,7 @@ Tutorial
 
 pnictogen can currently create boilerplates for
 `ADF <https://www.scm.com/product/adf/>`_,
+`DALTON <http://daltonprogram.org/>`_,
 `GAMESS (US) <http://www.msg.ameslab.gov/GAMESS/GAMESS.html>`_,
 `GAMESS-UK <http://www.cfs.dl.ac.uk/>`_,
 `Gaussian <http://www.gaussian.com/>`_,

--- a/config.yml
+++ b/config.yml
@@ -1,5 +1,5 @@
 packages:
-  # TODO: add DALTON (not available through Open Babel)
+
   ADF:
     boilerplate: |+
       TITLE {{ molecules[0].title }}
@@ -20,6 +20,9 @@ packages:
       End
 
 
+  DALTON:
+    boilerplate: |+
+      {{ molecules[0].write('dalmol')}}
 
   GAMESS:
     boilerplate: |+1


### PR DESCRIPTION
This adds a DALTON boilerplate to the config, because Open Babel can generate the inputs.

Is it correct that all of the boilerplates in `examples/boilerplates` technically don't need to be there, and all of the defaults are always generated from `config.yml`? I ask because

1. Duplicating all of the templates will make maintaining them harder. I understand that `examples/templates` are _not_ boilerplates, but are more complex examples of what you can do with templates.

2. Most of the commands in the boilerplates are specific to pybel. I'm thinking of how to add cclib support (maybe a selectable YAML config?) alongside pybel. There is a cclib-to-pybel bridge that could replace pybel here, but they should probably coexist since the pybel boilerplates are so simple, and I'm not sure that the cclib bridge is feature complete.